### PR TITLE
Added disabling of the calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,15 @@ Name: My Google Calendar
 URL: https://calendar.google.com/calendar/ical/XXXXXXXXXXXXXX/public/basic.ics
 Channel: @mychannel
 Verified: True
+Enabled: True
+Last processed: 2022-01-07T11:55:09.762176
+Last error: None
+Errors count: 0
 
-/delete it or /cancel
+/disable /delete or /cancel
 ```
 
-Then you can delete this calendar by selecting /delete command.
+Then you can `/enable` or `/disable` the calendar or `/delete` it permanently by executing the specific command.
 
 ### /format
 

--- a/calbot.cfg.sample
+++ b/calbot.cfg.sample
@@ -3,6 +3,7 @@ token = 225478221:AAFvpu4aBjixXmDJKAWVO3wNMjWFpxlkcHY
 vardir = var
 interval = 3600
 bootstrap_retries = -1
+errors_count_threshold = 3
 
 #[polling]
 #poll_interval = 15

--- a/calbot/bot.py
+++ b/calbot/bot.py
@@ -128,7 +128,8 @@ def list_calendars(bot, update, config):
     user_id = str(message.chat_id)
     text = 'ID\tNAME\tCHANNEL\n'
     for calendar in config.user_calendars(user_id):
-        text += '/cal%s\t%s\t%s\n' % (calendar.id, calendar.name, calendar.channel_id)
+        text += '/cal%s\t%s\t%s%s\n' % (calendar.id, calendar.name, calendar.channel_id,
+                                        ('' if calendar.enabled else '\tDISABLED'))
     bot.sendMessage(chat_id=user_id, text=text)
 
 
@@ -163,7 +164,7 @@ def unknown(bot, update):
     :param update: Update instance
     :return: None
     """
-    bot.sendMessage(chat_id=update.message.chat_id, text="Sorry, I don't understand that command.")
+    bot.sendMessage(chat_id=update.message.chat_id, text="Sorry, I don't understand this command.")
 
 
 def error(bot, update, error):

--- a/calbot/classes.puml
+++ b/calbot/classes.puml
@@ -1,0 +1,88 @@
+@startuml
+
+class Config <<Persist>> {
+  vardir
+  token
+  interval
+  bootstrap_retries
+  errors_count_threshold
+  poll_interval
+  timeout
+  read_latency
+  webhook
+  domain
+  listen
+  port
+}
+
+class UserConfig <<Persist>> {
+    user_id
+    format
+    language
+    advance
+    errors_count_threshold
+}
+
+Config *-- UserConfig
+
+class CalendarConfig <<Persist>> {
+    id
+    user_id^
+    url
+    name
+    channel_id
+    verified
+    enabled
+    format^
+    language^
+    advance^
+    day_start
+    last_process_at
+    last_process_error
+    last_errors_count
+    errors_count_threshold^
+}
+
+UserConfig *-- CalendarConfig
+
+class Calendar <<Runtime>> {
+    url
+    advance
+    day_start
+    name
+    timezone
+    description
+}
+
+CalendarConfig -* Calendar
+
+class EventConfig <<Persist>> {
+    id
+    cal_id
+    user_id
+    last_notified
+}
+
+class Event <<Runtime>> {
+    id
+    uid
+    instance_id
+    title
+    date
+    location
+    description
+    date
+    time
+    notify_datetime
+    repeat_rule
+    exception_dates
+    recurrence_id
+    notified_for_advance
+    day_start
+}
+
+EventConfig -* Event
+
+Calendar *-- "*" Event
+
+@enduml

--- a/calbot/processing.py
+++ b/calbot/processing.py
@@ -64,6 +64,9 @@ def update_calendar(bot, config):
     :param config: CalendarConfig instance to persist and update events notification status
     :return: None
     """
+    if not config.enabled:
+        logger.info('Skipping processing of disabled calendar %s of user %s', config.id, config.user_id)
+        return
     try:
         calendar = Calendar(config)
         for event in calendar.events:
@@ -84,10 +87,16 @@ Channel: %s''' % (config.id, config.name, config.url, config.channel_id))
         if not config.verified:
             try:
                 bot.sendMessage(chat_id=config.user_id,
-                                text='Failed to process calendar %s:\n%s' % (config.id, e))
+                                text='Failed to process calendar /cal%s:\n%s' % (config.id, e))
             except Exception:
                 logger.error('Failed to send message to user %s', config.user_id, exc_info=True)
         config.save_error(e)
+        if not config.enabled:
+            try:
+                bot.sendMessage(chat_id=config.user_id,
+                                text='Calendar /cal%s is disabled due too many processing errors\n' % config.id)
+            except Exception:
+                logger.error('Failed to send message to user %s', config.user_id, exc_info=True)
 
 
 def send_event(bot, config, event):


### PR DESCRIPTION
Each calendar can be disabled or enabled back automatically.
Also, the calendar is automatically disabled if its processing failed with an error the specified amount of times (12 by default, which means it fails continuously no more than 12 hours).